### PR TITLE
fixing sidebar open on firefox>=73

### DIFF
--- a/core/src/background.js
+++ b/core/src/background.js
@@ -1,6 +1,12 @@
 // Called when the user presses Alt+Q
 function handleShortcut(command) {
-    browser.sidebarAction.open();
+    var match = window.navigator.userAgent.match(/Firefox\/([0-9]+)\./);
+    var ver = match ? parseInt(match[1]) : 0;
+    if (ver>=73){
+        browser.sidebarAction.toggle();
+    }else {
+        browser.sidebarAction.open();
+    }
 }
 
 browser.commands.onCommand.addListener(handleShortcut);  


### PR DESCRIPTION
Since firefox >= 73 the sidebar can be open using `sidebarAction.toggle()`   
links to the documentation : https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/sidebarAction/toggle   
I've made a few changes to include older version as well.   
