### PR TITLE
fixing url query

### DIFF
--- a/core/src/sidebar/sidebar.js
+++ b/core/src/sidebar/sidebar.js
@@ -130,8 +130,20 @@ function searchBar() {
     const currentTab = tabs[0];
     let url;
 
-    if (query.startsWith("http://") || query.startsWith("https://") || query.startsWith("about:")) {
-      url = query;
+    const isValidUrl = urlString => {
+      var urlPattern = new RegExp('^(https?:\\/\\/)?' + 
+        '((([a-z\\d]([a-z\\d-]*[a-z\\d])*)\\.)+[a-z]{2,}|' + 
+        '((\\d{1,3}\\.){3}\\d{1,3}))' + 
+        '(\\:\\d+)?(\\/[-a-z\\d%_.~+]*)*' +
+        '(\\?[;&a-z\\d%_.~+=-]*)?' + 
+        '(\\#[-a-z\\d_]*)?$', 'i'); 
+      return !!urlPattern.test(urlString);
+    }
+
+    if (isValidUrl(query)) {
+      if (!(query.startsWith('http'))) {
+        url = "http://" + query;
+      } else { url = query; }
     } else {
       url = "https://www.google.com/search?q=" + encodeURIComponent(query);
     }


### PR DESCRIPTION
## Why this pr  ?
I had a problem when I typed for instance "discord.com/app" (which is valid url) but I wasn't redirected to it (because it didn't start with http), so it just started to google "discord.com/app" which is not what I wanted. 
In this commits : 
- I validate the urls using a (big) regex 
- if the url is valid, it is sent to `browser.tabs.update()` and that fix my problem. 
- if not, it is sent to  `"https://www.google.com/search?q=" + encodeURIComponent(query);` like before.  
*basically a lot of words for just adding a `if` statement* 

### Quoting from the doc : 
I had to append `http` to urls that doesn't contain it because firefox extension is not super friendly with "valid urls".
```
Fully-qualified URLs must include a scheme (for example, 'http://www.google.com' not 'www.google.com').

For security reasons, in Firefox, this may not be a privileged URL. So passing any of the following URLs will fail:

    chrome: URLs
    javascript: URLs
    data: URLs
    file: URLs (i.e., files on the filesystem. However, to use a file packaged inside the extension, see below)
```
### Other info 
Something that I need to mention is that a query that doesn't start with http* is redirected to `http` not `https`. 
For instance : if I type `www.google.com` arcfox will send me to `http://www.google.com` and then the google server will redirect me to `https://www.google.com` 
The reason behind this is that I cannot know in advance if the website is in `http` or `https`. More info on this stackoverflow post I made : https://stackoverflow.com/questions/76120582/javascript-convert-hostname-url-into-full-url 
